### PR TITLE
Deprecated usages of Caffe

### DIFF
--- a/resume_training.py
+++ b/resume_training.py
@@ -15,8 +15,8 @@ def main():
   solver = caffe.SGDSolver('solver.prototxt')
   solver.solve(solver_state) # load even *.caffemodel
 
-  solver.net.set_mode_gpu()
-  solver.net.set_device(0)
+  caffe._caffe.set_mode_gpu()
+  caffe._caffe.set_device(0)
   
   test_interval = 1000
   max_iter = 200000

--- a/resume_training.py
+++ b/resume_training.py
@@ -12,11 +12,11 @@ def main():
   iter_num = process_arguments(sys.argv)
   solver_state = 'models/train_iter_{}.solverstate'.format(iter_num)
 
-  solver = caffe.SGDSolver('solver.prototxt')
-  solver.solve(solver_state) # load even *.caffemodel
-
   caffe._caffe.set_mode_gpu()
   caffe._caffe.set_device(0)
+  
+  solver = caffe.SGDSolver('solver.prototxt')
+  solver.solve(solver_state) # load even *.caffemodel
   
   test_interval = 1000
   max_iter = 200000

--- a/solve.py
+++ b/solve.py
@@ -45,8 +45,8 @@ interp_surgery(solver.net, interp_layers)
 
 # copy base weights for fine-tuning
 solver.net.copy_from(base_weights)
-solver.net.set_mode_gpu()
-solver.net.set_device(0)
+caffe._caffe.set_mode_gpu()
+caffe._caffe.set_device(0)
 
 ## control layer's initialization
 halt_training = False


### PR DESCRIPTION
- The new caffe (also the caffe version used by CRF as RNN) removes the set_mode_gpu function from net, and instead use the caffe.set_mode_gpu. ([reference comments](https://github.com/martinkersner/train-CRF-RNN/issues/20#issuecomment-226079543))
- The set_mode_gpu() statements take effect only when they are executed before solver.solve(solver_state).
